### PR TITLE
update for upcoming hubot@3

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,12 +20,13 @@ Let's assume you've got a really simple script, like this:
     };
 
 You want to test this, of course.  So create a Mocha test:
-    
+
     var expect = require("chai").expect;
     var path   = require("path");
 
-    var Robot       = require("hubot/src/robot");
-    var TextMessage = require("hubot/src/message").TextMessage;
+    var Hubot       = require("hubot");
+    var Robot       = Hubot.Robot;
+    var TextMessage = Hubot.TextMessage;
 
     describe("Eddie the shipboard computer", function() {
         var robot;
@@ -57,7 +58,7 @@ You want to test this, of course.  So create a Mocha test:
                 });
 
                 adapter = robot.adapter;
-                
+
                 done();
             });
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ I couldn't find an existing method for writing unit tests for Hubot scripts.
 After digging around under Hubot's hood, I figured out all I really needed was
 an `Adapter` implementation I could spy on.  That is what you see here.
 
+
 ## example usage
 
 Let's assume you've got a really simple script, like this:

--- a/index.js
+++ b/index.js
@@ -1,58 +1,30 @@
-"use strict";
+'use strict';
 
-// boilerplate CoffeeScript for class inheritance
-var __extends = function(child, parent) {
-    for (var key in parent) {
-        if (Object.hasOwnProperty.call(parent, key)) {
-            child[key] = parent[key];
-        }
-    }
-    
-    function Ctor() {
-        this.constructor = child;
-    }
-    
-    Ctor.prototype = parent.prototype;
-    child.prototype = new Ctor();
-    child.__super__ = parent.prototype;
-    
-    return child;
-};
+const Adapter = require('hubot/es2015').Adapter;
 
-// our stuff starts here
-var Adapter = require("hubot/src/adapter");
-var _       = require("lodash");
-
-function MockAdapter() {
-    var self = this;
-    
-    function genericEmitter(event) {
-        return function(envelope) {
-            var args = _.collect(arguments);
-            var strings = _.rest(args);
-            
-            self.emit(event, envelope, strings);
-        };
-    }
-    
-    self.send  = genericEmitter("send");
-    self.reply = genericEmitter("reply");
-    self.topic = genericEmitter("topic");
-    self.play  = genericEmitter("play");
-    
-    self.run = function() {
-        self.emit("connected");
-    };
-    
-    self.close = function() {
-        self.emit("closed");
-    };
-    
-    return MockAdapter.__super__.constructor.apply(this, arguments);
+class MockAdapter extends Adapter {
+  send (envelope/* , ...strings */) {
+    const strings = [].slice.call(arguments, 1);
+    this.emit('send', envelope, strings);
+  }
+  reply (envelope/* , ...strings */) {
+    const strings = [].slice.call(arguments, 1);
+    this.emit('reply', envelope, strings);
+  }
+  topic (envelope/* , ...strings */) {
+    const strings = [].slice.call(arguments, 1);
+    this.emit('topic', envelope, strings);
+  }
+  play (envelope/* , ...strings */) {
+    const strings = [].slice.call(arguments, 1);
+    this.emit('play', envelope, strings);
+  }
+  run () {
+    this.emit('connected');
+  }
+  close () {
+    this.emit('closed');
+  }
 }
 
-__extends(MockAdapter, Adapter);
-
-module.exports.use = function(robot) {
-    return new MockAdapter(robot);
-};
+module.exports.use = robot => new MockAdapter(robot);


### PR DESCRIPTION
`hubot-mock-adapter` is currently used in many scripts for testing. In `hubot` itself [we moved the mock adapter into the hubot codebase](https://github.com/hubotio/hubot/blob/master/test/fixtures/mock-adapter.js) but would like to use an external package again.

Ideally we would like to move this repository to the new `hubotio` organisation and would like to take over the `npm` package so we can release a new version. 

Would that be okay with you?