### PR TITLE
Travis: bump node versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ sudo: false
 notifications:
   email: false
 node_js:
-  - "10"
-  - "8"
-  - "6"
+  - "16"
+  - "14"
+  - "12"
 before_install:
   - npm install -g npm@latest
 before_script:


### PR DESCRIPTION
Node 10 is the minimum for current NPM, and we should probably be testing this on only the three most recent Node versions.