### PR TITLE
chore: make docs actually work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,88 +1,86 @@
 # mock adapter for unit-testing Hubot
 
 I've whacked together a couple of Hubot scripts, but then they started getting
-more complicated.  TDD is really the ONLY way to do any kind of meaningful
-development.  But even if you're not TDD'ing, you *are* testing, right?
+more complicated. TDD is really the ONLY way to do any kind of meaningful
+development. But even if you're not TDD'ing, you _are_ testing, right?
 _Right_?
 
 I couldn't find an existing method for writing unit tests for Hubot scripts.
 After digging around under Hubot's hood, I figured out all I really needed was
-an `Adapter` implementation I could spy on.  That is what you see here.
-
+an `Adapter` implementation I could spy on. That is what you see here.
 
 ## example usage
 
 Let's assume you've got a really simple script, like this:
 
 ```js
-module.exports = function(robot) {
-    robot.hear(/Computer!/, function(msg) {
-        msg.reply("Why hello there! (ticker tape, ticker tape)");
-    });
+module.exports = function (robot) {
+  robot.hear(/Computer!/, function (msg) {
+    msg.reply("Why hello there! (ticker tape, ticker tape)");
+  });
 };
 ```
 
-You want to test this, of course.  So create a Mocha test:
+You want to test this, of course. So create a Mocha test:
 
-
-```js    
+```js
 var expect = require("chai").expect;
-var path   = require("path");
+var path = require("path");
 
-var Robot       = require("hubot/src/robot");
-var TextMessage = require("hubot/src/message").TextMessage;
+var Robot = require("hubot/es2015").Robot;
+var TextMessage = require("hubot").TextMessage;
 
-describe("Eddie the shipboard computer", function() {
-    var robot;
-    var user;
-    var adapter;
+describe("Eddie the shipboard computer", function () {
+  var robot;
+  var user;
+  var adapter;
 
-    beforeEach(function(done) {
-        // create new robot, without http, using the mock adapter
-        robot = new Robot(null, "mock-adapter", false, "Eddie");
+  beforeEach((done) => {
+    // create new robot, without http, using the mock adapter
+    robot = new Robot("hubot-mock-adapter", false, "Eddie");
 
-        robot.adapter.on("connected", function() {
-            // only load scripts we absolutely need, like auth.coffee
-            process.env.HUBOT_AUTH_ADMIN = "1";
-            robot.loadFile(
-                path.resolve(
-                    path.join("node_modules/hubot/src/scripts")
-                ),
-                "auth.coffee"
-            );
+    // start adapter
+    robot.loadAdapter().then(() => {
+      // only load scripts we absolutely need, like auth.coffee
+      process.env.HUBOT_AUTH_ADMIN = "1";
+      robot.loadFile(
+        path.resolve(path.join("node_modules/hubot/src/scripts")),
+        "auth.coffee"
+      );
 
-            // load the module under test and configure it for the
-            // robot.  This is in place of external-scripts
-            require("../index")(robot);
+      // load the module under test and configure it for the
+      // robot.  This is in place of external-scripts
+      require("../index")(robot);
 
-            // create a user
-            user = robot.brain.userForId("1", {
-                name: "mocha",
-                room: "#mocha"
-            });
-
-            adapter = robot.adapter;
-                
-            done();
+      robot.adapter.on("connected", () => {
+        // create a user
+        user = robot.brain.userForId("1", {
+          name: "mocha",
+          room: "#mocha",
         });
+        adapter = robot.adapter;
+        done();
+      });
 
-        robot.run();
+      // start the bot
+      robot.run();
+    });
+  });
+
+  afterEach(function () {
+    robot.shutdown();
+  });
+
+  it("responds when greeted", function (done) {
+    // here's where the magic happens!
+    adapter.on("reply", function (envelope, strings) {
+      expect(strings[0]).match(/Why hello there/);
+
+      done();
     });
 
-    afterEach(function() {
-        robot.shutdown();
-    });
-
-    it("responds when greeted", function(done) {
-        // here's where the magic happens!
-        adapter.on("reply", function(envelope, strings) {
-            expect(strings[0]).match(/Why hello there/);
-
-            done();
-        });
-
-        adapter.receive(new TextMessage(user, "Computer!"));
-    });
+    adapter.receive(new TextMessage(user, "Computer!"));
+  });
 });
 ```
 


### PR DESCRIPTION
I recently ditched `hubot-pretend` for `hubot-mock-adapter` for the `hubot-command-mapper` package. When I tried the example it did not work, as the _adapter_ was not loaded. I refactored the example a bit, and it now works out of the box.

_Note: to make testing even easier we could ship some extra utility classes, but it gets opinionated quickly. I did a small write-up on what we did for the command mapper: [https://keestalkstech.com/2023/08/hubot-testing-revisited/]( https://keestalkstech.com/2023/08/hubot-testing-revisited/)_